### PR TITLE
Fixed: coroutines can't be canceled.

### DIFF
--- a/data/src/main/java/com/no1/taiwan/comicbooker/data/repositories/BookerDataRepository.kt
+++ b/data/src/main/java/com/no1/taiwan/comicbooker/data/repositories/BookerDataRepository.kt
@@ -9,8 +9,9 @@ import com.no1.taiwan.comicbooker.data.datastores.DataStore
 import com.no1.taiwan.comicbooker.data.local.cache.AbsCache
 import com.no1.taiwan.comicbooker.domain.parameters.Parameterable
 import com.no1.taiwan.comicbooker.domain.repositories.DataRepository
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 
@@ -33,15 +34,15 @@ class BookerDataRepository constructor(
     private val bookerMapper by lazy { digDataMapper<BookerMapper>() }
 
     // TODO(jieyi): 2018/09/19 Added try catch for get a mapper from di.
-    override fun fetchTest(parameters: Parameterable) =
-        GlobalScope.async(Dispatchers.Default) {
+    override fun fetchTest(parameters: Parameterable, parentJob: Job) =
+        GlobalScope.async(IO + parentJob) {
             delay(3000)
             val data = remote.retrieveTest(parameters).await()
             testMapper.toModelFrom(data)
         }
 
     override fun fetchBooker(parameters: Parameterable) =
-        GlobalScope.async(Dispatchers.Default) {
+        GlobalScope.async(IO) {
             val data = local.retrieveBookerData(parameters).await()
             data.map(bookerMapper::toModelFrom)
         }

--- a/domain/src/main/java/com/no1/taiwan/comicbooker/domain/DeferredUsecase.kt
+++ b/domain/src/main/java/com/no1/taiwan/comicbooker/domain/DeferredUsecase.kt
@@ -20,7 +20,7 @@ abstract class DeferredUsecase<T : Any, R : BaseUsecase.RequestValues> : BaseUse
             if (parentJob.isCancelled)
                 parentJob = Job()
 
-            GlobalScope.async(IO + parentJob) { Success(fetchCase()) }.await()
+            GlobalScope.async(IO) { Success(fetchCase(parentJob)) }.await()
         }
         catch (cancel: CancellationException) {
             cancel.printStackTrace()
@@ -32,7 +32,7 @@ abstract class DeferredUsecase<T : Any, R : BaseUsecase.RequestValues> : BaseUse
         }
     }
 
-    abstract suspend fun fetchCase(): T
+    abstract suspend fun fetchCase(parentJob: Job): T
 
     protected fun attachParameter(λ: suspend (R) -> T) = runBlocking { requireNotNull(requestValues?.run { λ(this) }) }
 }

--- a/domain/src/main/java/com/no1/taiwan/comicbooker/domain/repositories/DataRepository.kt
+++ b/domain/src/main/java/com/no1/taiwan/comicbooker/domain/repositories/DataRepository.kt
@@ -4,12 +4,13 @@ import com.no1.taiwan.comicbooker.domain.models.BookerModel
 import com.no1.taiwan.comicbooker.domain.models.TestModel
 import com.no1.taiwan.comicbooker.domain.parameters.Parameterable
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Job
 
 /**
  * This interface will be the similar to [com.no1.taiwan.comicbooker.data.datastores.DataStore] .
  */
 interface DataRepository {
-    fun fetchTest(parameters: Parameterable): Deferred<TestModel>
+    fun fetchTest(parameters: Parameterable, parentJob: Job): Deferred<TestModel>
 
     fun fetchBooker(parameters: Parameterable): Deferred<List<BookerModel>>
 }

--- a/domain/src/main/java/com/no1/taiwan/comicbooker/domain/usecases/GetBookersUsecase.kt
+++ b/domain/src/main/java/com/no1/taiwan/comicbooker/domain/usecases/GetBookersUsecase.kt
@@ -5,11 +5,12 @@ import com.no1.taiwan.comicbooker.domain.models.BookerModel
 import com.no1.taiwan.comicbooker.domain.parameters.BookerParams
 import com.no1.taiwan.comicbooker.domain.repositories.DataRepository
 import com.no1.taiwan.comicbooker.domain.usecases.GetBookersUsecase.Request
+import kotlinx.coroutines.Job
 
 class GetBookersUsecase(
     private val repository: DataRepository
 ) : DeferredUsecase<List<BookerModel>, Request>() {
-    override suspend fun fetchCase() = attachParameter {
+    override suspend fun fetchCase(parentJob: Job) = attachParameter {
         repository.fetchBooker(it.parameters).await()
     }
 

--- a/domain/src/main/java/com/no1/taiwan/comicbooker/domain/usecases/TestUsecase.kt
+++ b/domain/src/main/java/com/no1/taiwan/comicbooker/domain/usecases/TestUsecase.kt
@@ -5,12 +5,13 @@ import com.no1.taiwan.comicbooker.domain.models.TestModel
 import com.no1.taiwan.comicbooker.domain.parameters.BookerParams
 import com.no1.taiwan.comicbooker.domain.repositories.DataRepository
 import com.no1.taiwan.comicbooker.domain.usecases.TestUsecase.Request
+import kotlinx.coroutines.Job
 
 class TestUsecase(
     private val repository: DataRepository
 ) : DeferredUsecase<TestModel, Request>() {
-    override suspend fun fetchCase() = attachParameter {
-        repository.fetchTest(it.parameters).await()
+    override suspend fun fetchCase(parentJob: Job) = attachParameter {
+        repository.fetchTest(it.parameters, parentJob).await()
     }
 
     class Request(val parameters: BookerParams = BookerParams()) : RequestValues

--- a/presentation/src/main/java/com/no1/taiwan/comicbooker/components/viewmodel/AutoViewModel.kt
+++ b/presentation/src/main/java/com/no1/taiwan/comicbooker/components/viewmodel/AutoViewModel.kt
@@ -12,7 +12,6 @@ open class AutoViewModel : ViewModel() {
      * prevent a leak of this ViewModel.
      */
     override fun onCleared() {
-        // FIXME(jieyi): 2018-10-30 task couldn't stop.
         // Search all variables including private.
         this::class.java.declaredFields.forEach {
             val usecaseSuperclass = it.type.superclass

--- a/presentation/src/main/java/com/no1/taiwan/comicbooker/features/main/MainViewModel.kt
+++ b/presentation/src/main/java/com/no1/taiwan/comicbooker/features/main/MainViewModel.kt
@@ -1,7 +1,6 @@
 package com.no1.taiwan.comicbooker.features.main
 
 import com.no1.taiwan.comicbooker.components.viewmodel.AutoViewModel
-import com.no1.taiwan.comicbooker.domain.usecases.GetBookersUsecase
 import com.no1.taiwan.comicbooker.domain.usecases.TestUsecase
 import com.no1.taiwan.comicbooker.entities.PresentationBookerMapper
 import com.no1.taiwan.comicbooker.entities.PresentationTestMapper
@@ -12,7 +11,7 @@ import com.no1.taiwan.comicbooker.ext.toRun
 
 class MainViewModel(
     private val usecase: TestUsecase,
-    private val usecase2: GetBookersUsecase,
+//    private val usecase2: GetBookersUsecase,
     private val mapper: PresentationTestMapper,
     private val mapper2: PresentationBookerMapper
 ) : AutoViewModel() {

--- a/presentation/src/main/java/com/no1/taiwan/comicbooker/internal/di/dependency/activity/MainModule.kt
+++ b/presentation/src/main/java/com/no1/taiwan/comicbooker/internal/di/dependency/activity/MainModule.kt
@@ -12,7 +12,7 @@ object MainModule {
     fun mainProvider() = Module("Main Module") {
         // *** ViewModel
         bind<ViewModelEntry>().inSet() with provider {
-            MainViewModel::class.java to MainViewModel(instance(), instance(), instance(), instance())
+            MainViewModel::class.java to MainViewModel(instance(), instance(), instance())
         }
     }
 }


### PR DESCRIPTION
ref #7 issue

Just workaround, send the parentJob from domain layer to data layer.